### PR TITLE
Keep owner in resource info, not only when admin

### DIFF
--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -330,6 +330,14 @@ def make_status_response(info, admin=False):
     """Check the annotation status for a given corpus and return response."""
     info_attrs = info.to_dict()
 
+    if not admin:
+        # Only keep essential information, as this can be shown to other resource users than the owner
+        info_attrs["owner"] = {
+            "id": info_attrs["owner"]["id"],
+            "name": info_attrs["owner"]["name"],
+            "email": info_attrs["owner"]["email"],
+        }
+
     status = info.job.status
 
     if status.is_none():

--- a/mink/sparv/process_routes.py
+++ b/mink/sparv/process_routes.py
@@ -330,9 +330,6 @@ def make_status_response(info, admin=False):
     """Check the annotation status for a given corpus and return response."""
     info_attrs = info.to_dict()
 
-    if not admin:
-        info_attrs.pop("owner")
-
     status = info.job.status
 
     if status.is_none():


### PR DESCRIPTION
The `'owner'` part of the resource info response is currently stripped away unless the user is in admin mode. This makes the API more complicated, and I cannot see any reason for it. It doesn't contain any information that the user shouldn't see.

I suppose the API documentation should be updated too, but I'm not sure how...